### PR TITLE
Remove ViewProps from being extended of component type

### DIFF
--- a/src/PdfRendererView.tsx
+++ b/src/PdfRendererView.tsx
@@ -28,7 +28,8 @@ import {
   ViewProps,
 } from 'react-native';
 
-export type PdfRendererViewPropsType = ViewProps & {
+export type PdfRendererViewPropsType = {
+  style?: ViewProps['style'],
   source?: string;
   distanceBetweenPages: number;
   maxZoom: number;


### PR DESCRIPTION
Some View props when passed to the native iOS View cause an execution error. To avoid future problems, this PR removes the possibility of it being extended from ViewProps type from the component's typing.

Also added the possibility of passing only one prop style.