### PR TITLE
Fix `defaultProps` warning

### DIFF
--- a/src/PdfRendererView.tsx
+++ b/src/PdfRendererView.tsx
@@ -52,7 +52,7 @@ const styles = StyleSheet.create({
 });
 
 const PdfRendererView = (props: PdfRendererViewPropsType): JSX.Element => {
-  const {onPageChange, style, source, singlePage, maxZoom, ...others} = props;
+  const {onPageChange, style, source, singlePage = false, maxZoom = 5, distanceBetweenPages = 16, ...others} = props;
 
   const viewStyles = useMemo(() => [styles.default, style, {
     // See https://github.com/douglasjunior/react-native-pdf-renderer#limitations
@@ -78,17 +78,12 @@ const PdfRendererView = (props: PdfRendererViewPropsType): JSX.Element => {
   return (
     <PdfRendererNative
       {...others}
+      distanceBetweenPages={distanceBetweenPages}
       style={viewStyles}
       params={params}
       onPageChange={handlePageChange}
     />
   );
-};
-
-PdfRendererView.defaultProps = {
-  maxZoom: 5,
-  distanceBetweenPages: 16,
-  singlePage: false,
 };
 
 export default PdfRendererView;


### PR DESCRIPTION
I've got this warning with Expo 51 & RN 0.74 & React 18.2.

`Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.`