### PR TITLE
Use React 19 compatible JSX type

### DIFF
--- a/src/PdfRendererView.tsx
+++ b/src/PdfRendererView.tsx
@@ -104,7 +104,7 @@ const PdfRendererView = ({
   distanceBetweenPages = 16,
   maxZoom = 5,
   maxPageResolution = 2048,
-}: PdfRendererViewPropsType): JSX.Element => {
+}: PdfRendererViewPropsType): React.JSX.Element => {
   const viewStyles = useMemo(
     () => [
       styles.default,


### PR DESCRIPTION
If you use this dependency in an app using React 19, at the moment you'll get a type error, because:

> A long-time request is to remove the global JSX namespace from our types in favor of React.JSX. This helps prevent pollution of global types which prevents conflicts between different UI libraries that leverage JSX.

From [here][1]. `React.JSX` exists in React 18, so this change is backwards compatible.

[1]: https://react.dev/blog/2024/04/25/react-19-upgrade-guide#the-jsx-namespace-in-typescript

The error:

```
Whatever.tsx:33:10 - error TS2786: 'PdfRendererView' cannot be used as a JSX component.
  Its type '({ testID, onPageChange, style, source, singlePage, distanceBetweenPages, maxZoom, maxPageResolution, }: PdfRendererViewPropsType) => Element' is not a valid JSX element type.
    Type '({ testID, onPageChange, style, source, singlePage, distanceBetweenPages, maxZoom, maxPageResolution, }: PdfRendererViewPropsType) => Element' is not assignable to type '(props: any) => ReactNode | Promise<ReactNode>'.
      Type 'Element' is not assignable to type 'ReactNode | Promise<ReactNode>'.
        Property 'children' is missing in type 'ReactElement<any, any>' but required in type 'ReactPortal'.

33         <PdfRendererView
            ~~~~~~~~~~~~~~~

  ../../node_modules/.pnpm/@types+react@19.0.14/node_modules/@types/react/index.d.ts:387:9
    387         children: ReactNode;
                ~~~~~~~~
    'children' is declared here.
```