### PR TITLE
Workaround fix for PDF rendering issue when scaleFactorForSizeToFit is zero

### DIFF
--- a/ios/ReactNativePdfRendererLibrary/RNPDFView.mm
+++ b/ios/ReactNativePdfRendererLibrary/RNPDFView.mm
@@ -61,13 +61,20 @@ NSNotificationName const RNPDFViewErrorNotification = @"RNPDFViewErrorNotificati
             self.document = pdfDocument;
         });
         
-        dispatch_async(dispatch_get_main_queue(), ^{
-            self.minScaleFactor = self.scaleFactorForSizeToFit;
-            if (maxZoom > 0) {
-                self.maxScaleFactor = self.scaleFactorForSizeToFit * maxZoom;
-            }
-            [self setNeedsLayout];
-        });
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+            // In certain scenarios, scaleFactorForSizeToFit may be 0.
+            // This results in invalid calculations for the CoreGraphics API, affecting the PDF positioning.
+            // Consequence: PDF displayed in the wrong position and zoom unavailable.
+            // This is a temporary workaround to handle the production bug until a better approach is implemented.
+            sleep(1);
+
+            dispatch_async(dispatch_get_main_queue(), ^{
+                self.minScaleFactor = self.scaleFactorForSizeToFit == 0 ? 1 : self.scaleFactorForSizeToFit;
+                if (maxZoom > 0) {
+                    self.maxScaleFactor = maxZoom * self.minScaleFactor;
+                }
+                [self setNeedsLayout];
+            });
     } else {
         self.document = nil;
     }


### PR DESCRIPTION
In some cases, the value of `scaleFactorForSizeToFit` can be 0. When this happens, the calculated result also becomes 0, which is invalid for the CoreGraphics API. As a result, the PDF will be rendered on screen with incorrect positioning, and zoom controls will not work.

The following fix is a temporary workaround for a production issue, to be replaced with a more robust solution in the future.