### PR TITLE
Disable native view recycling on iOS

### DIFF
--- a/ios/ReactNativePdfRendererLibrary/RNPdfRendererComponentView.mm
+++ b/ios/ReactNativePdfRendererLibrary/RNPdfRendererComponentView.mm
@@ -58,6 +58,14 @@ BOOL observerAdded = NO;
     return self;
 }
 
++(BOOL)shouldBeRecycled
+{
+    // We are disabling recycling for this native view to prevent it from being cached.
+    // This ensures that the PDF is reloaded every time the component is re-mounted
+    // or any of its props change, providing a fresh instance for each render.
+    return NO;
+}
+
 - (void)dealloc
 {
     if (observerAdded) {


### PR DESCRIPTION
This pull request disables the recycling of the native PDF view by overriding the `shouldBeRecycled` method to return `NO`. With this change, the native view will not be cached, ensuring that the PDF is reloaded every time the component is unmounted or any of its props change.

## Before

https://github.com/user-attachments/assets/990ad85c-634c-4144-8ea4-12bee24584b7

## After

https://github.com/user-attachments/assets/b5a705f2-2bbc-49d0-80f6-f8efd118b4fb

