### PR TITLE
Fix: Add missing SafeAreaView import in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ buildscript {
 There is only one component that you need to use to render the PDF file.
 
 ```jsx
+import { SafeAreaView } from 'react-native-safe-area-context';
 import PdfRendererView from 'react-native-pdf-renderer';
 
 const App = () => {


### PR DESCRIPTION
The example uses SafeAreaView but does not import it, which causes errors when copy-pasting.
This PR adds the required import for clarity.